### PR TITLE
Resolves #1 by adding a footer message about nonprofit status

### DIFF
--- a/_includes/organisms/copyright.html
+++ b/_includes/organisms/copyright.html
@@ -29,6 +29,16 @@
           is subject to the <a href="{{ site.github.license.url }}" itemprop="license">{{ site.github.license.name }}</a>.
         {% endif %}
       </div>
+
+      <p class="">
+        <strong>Status note</strong>: Lower Barriers is incorporated in the <abbr title="United States of America">US</abbr>
+        state of Michigan per its
+        <a href="http://www.legislature.mi.gov/(S(ruml4pdfjw2wkrmrz3fed0fs))/mileg.aspx?page=GetObject&objectname=mcl-act-162-of-1982">
+          Nonprofit Corporation Act
+        </a>. Lower Barriers is not a Federally-recognized 501(c)(3) nonprofit organization, though we intend to apply for
+        Federal nonprofit status in the year 2022. Your donations and financial contributions may not be text-deductible.
+      </p>
+
       {% include molecules/menu.html menu="copyright" classes="border-spaced display--flex layout--row menu-layout--horizontal" %}
     </div>
   </section>

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "terser": "terser _site/assets/js/behavior.js -o assets/js/pre-commit-dependency.js"
   },
   "devDependencies": {
-    "browserslist": "^4.16.6",
+    "browserslist": "^4.19.1",
     "dotenv": "^8.6.0",
     "dotenv-flow": "^3.2.0",
-    "prettier": "^2.2.1",
-    "purgecss": "^4.0.3",
+    "prettier": "^2.5.1",
+    "purgecss": "^4.1.3",
     "terser": "^4.6.6"
   }
 }


### PR DESCRIPTION
## What this PR does

  * Per lowerbarriers/lowerbarriers.github.io#1, this code change adds a status notification to the 'copyright' section of the footer that explains our current organizational status
  * PR includes an unrelated commit that updates a few npm packages per `npm audit fix`

## Review steps

- [ ] Clone the repository locally and follow the lowerbarriers/finished-starter local steps in the readme to start up a local environment on the `1_footer-message` branch (or fork the repository on GitHub and set the GitHub Pages branch to this one)
- [ ] Navigate to the local (or gh pages branch) hosting environment in your browser
- [ ] Ensure the footer message is present and contains no typos, formatting issues, or other blockers
- [ ] Ensure the footer message appears good, professional, and acceptable on desktop, tablet, and mobile devices
- [ ] Review the code as presented in the 'Files' tab of the PR
